### PR TITLE
Run RGI harvester on NRGI's ECS infrastructure

### DIFF
--- a/harvesters/rgi/Dockerfile
+++ b/harvesters/rgi/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine
+
+RUN apk --no-cache add \
+ curl \
+ python \
+ jq
+
+RUN curl -q https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+ && python get-pip.py
+
+COPY requirements.txt /tmp/requirements.txt
+WORKDIR /tmp
+RUN pip install -r requirements.txt
+
+COPY scripts /root/rgi_harvester
+
+WORKDIR /root/rgi_harvester
+
+CMD ./run_harvester.sh

--- a/harvesters/rgi/requirements.txt
+++ b/harvesters/rgi/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.13.0
+Unidecode==0.4.20

--- a/harvesters/rgi/scripts/get_pdfs.py
+++ b/harvesters/rgi/scripts/get_pdfs.py
@@ -86,7 +86,7 @@ for assessment in assessments:
             else:
                 assessment_type = "Unknown"
                 
-            law_practice_question = list(law_practice_question).sort()
+            law_practice_question = list(law_practice_question)
             law_practice_question.sort()
 
             new_dataset = {


### PR DESCRIPTION
## Why
Bundle the the RGI harvester in a Docker image so it can be run from the NRGI ECS infrastructure.

## What
- [x] a Dockerfile is created to build a Docker image that runs the RGI harvester
- [x] an ECS task is defined to run the RGI harvester that is put under source control in the `nrgi-dcos` repo
   - [x] env variables needed to properly run the RGI harvester are defined

## Notes
