### PR TITLE
Skip Summaries without countries

### DIFF
--- a/harvesters/eiti/scripts/extract_summary.py
+++ b/harvesters/eiti/scripts/extract_summary.py
@@ -262,7 +262,7 @@ def main():
     os.system("mkdir -p ./out/government")
     os.system("mkdir -p ./out/datasets")
 
-    sum_data = getSummaryData()
+    sum_data = [d for d in getSummaryData() if d.get('country', None)]
     total_len = len(sum_data)
     i = 0
 

--- a/harvesters/eiti/scripts/run_harvester.sh
+++ b/harvesters/eiti/scripts/run_harvester.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 mkdir ./out
 python ./extract_summary.py


### PR DESCRIPTION
Fixes #224.

EITI now has a summary dataset without a country tag. We'll skip it for now.