### PR TITLE
EITI harvester update

### DIFF
--- a/harvesters/eiti/scripts/eiti.py
+++ b/harvesters/eiti/scripts/eiti.py
@@ -30,6 +30,9 @@ def update_recent(dt):
 
     MOST_RECENT_CHANGE = max(dt, MOST_RECENT_CHANGE)
 
+def pr_safe(s):
+    return extract_summary.sanitizeCountryName(s)
+
 def checkForUpdates(summary):
     """ Checks the metadata and the years to see if we need to harvest
 
@@ -48,31 +51,31 @@ def checkForUpdates(summary):
 
     dataset = eiti_import.get_dataset(dataset_name)
     if not dataset:
-        print "New country spotted: %s" % (country)
+        print "New country spotted: %s" % (pr_safe(country))
         return True
 
     # check if there's any point in checking this...
     if not (summary.get('revenue_government',None)
             or summary.get('revenue_company',None)):
-        print "No company or government data, skipping %s, %s" % (country, year)
+        print "No company or government data, skipping %s, %s" % (pr_safe(country), year)
         return False
 
     # check changed, year
     if not (year in dataset['year']):
-        print "New year spotted for %s, %s" %(country, year)
+        print "New year spotted for %s, %s" %(pr_safe(country), year)
         return True
 
     dataset_modified = parseIsoTs(dataset['metadata_modified'])
 
     if summary_modified >= dataset_modified:
         print "Summary data has been updated for %s, %s: on %s, existing %s" %(
-            country, year,
+            pr_safe(country), year,
             time.strftime('%Y-%m-%d', summary_modified),
             time.strftime('%Y-%m-%d', dataset_modified))
         return True
 
     print "No change for %s, %s last updated %s" % (
-        country, year, time.strftime('%Y-%m-%d', summary_modified))
+        pr_safe(country), year, time.strftime('%Y-%m-%d', summary_modified))
     return False
 
 

--- a/harvesters/eiti/scripts/eiti.py
+++ b/harvesters/eiti/scripts/eiti.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+#
+# Script to only crawl the EITI data that has been reported changed.
+#
+# Relies heavily on the existing scripts to do the detail work
+#
+
+import time
+import requests
+import json
+
+import eiti_import
+import extract_summary
+
+session = requests.Session()
+MOST_RECENT_CHANGE = None
+
+def parseIsoTs(ts):
+    return time.strptime(ts.split('T')[0], '%Y-%m-%d')
+
+def hoist_country(summary):
+    return summary['country']['label']
+
+def update_recent(dt):
+    global MOST_RECENT_CHANGE
+
+    if not MOST_RECENT_CHANGE:
+        MOST_RECENT_CHANGE = dt
+
+    MOST_RECENT_CHANGE = max(dt, MOST_RECENT_CHANGE)
+
+def checkForUpdates(summary):
+    """ Checks the metadata and the years to see if we need to harvest
+
+    :param summary: entry,
+    :returns: True if we need to harvest, False if not
+    """
+
+    country = hoist_country(summary)
+    year = summary['label'][-4:]
+    # note that
+    summary_modified = parseIsoTs(summary['changed'])
+
+    update_recent(summary_modified)
+
+    dataset_name = extract_summary.dataset_name_fromCountry(country)
+
+    dataset = eiti_import.get_dataset(dataset_name)
+    if not dataset:
+        print "New country spotted: %s" % (country)
+        return True
+
+    # check if there's any point in checking this...
+    if not (summary.get('revenue_government',None)
+            or summary.get('revenue_company',None)):
+        print "No company or government data, skipping %s, %s" % (country, year)
+        return False
+
+    # check changed, year
+    if not (year in dataset['year']):
+        print "New year spotted for %s, %s" %(country, year)
+        return True
+
+    dataset_modified = parseIsoTs(dataset['metadata_modified'])
+
+    if summary_modified >= dataset_modified:
+        print "Summary data has been updated for %s, %s: on %s, existing %s" %(
+            country, year,
+            time.strftime('%Y-%m-%d', summary_modified),
+            time.strftime('%Y-%m-%d', dataset_modified))
+        return True
+
+    print "No change for %s, %s last updated %s" % (
+        country, year, time.strftime('%Y-%m-%d', summary_modified))
+    return False
+
+
+def fileName_fromUrl(country, url):
+    if 'company' in url:
+        return './out/company/%s-company.csv' % extract_summary.sanitizeCountryName(country)
+    else:
+        return './out/government/%s-government.csv' % extract_summary.sanitizeCountryName(country)
+
+def gather_csvs(country):
+    dataset_name = extract_summary.dataset_name_fromCountry(country)
+    dataset = eiti_import.get_dataset(dataset_name)
+    for resource in dataset['resources']:
+        url = resource['url']
+        print "Getting %s" % url
+        resp = session.get(url)
+        with open(fileName_fromUrl(country, url), 'wb') as f:
+            print "Writing %s" % fileName_fromUrl(country, url)
+            f.write(resp.content)
+
+def update_complete_dataset(filtered_summaries):
+    dataset = eiti_import.get_dataset('eiti-complete-summary-table')
+    dataset.update({
+        "filename": './out/all_unique.csv',
+        "filename_company": './out/all_unique_company.csv',
+        "filename_government": './out/all_unique_government.csv',
+        "resource_title_company": "Company payments",
+        "resource_title_government": "Revenues received by government agencies",
+
+    })
+
+
+    for summary in filtered_summaries:
+        country = hoist_country(summary)
+        country_iso3 = summary['country']['iso3']
+        year = summary['label'][-4:]
+
+        if not year in dataset['year']:
+            dataset['year'].append(year)
+        if not country in dataset['country']:
+            dataset['country'].append(country)
+        if not country_iso3 in dataset['country_iso3']:
+            dataset['country_iso3'].append(country_iso3)
+
+    dataset['year'].sort()
+    dataset['country'].sort()
+    dataset['country_iso3'].sort()
+
+    return dataset
+
+
+def main():
+    # SummaryData returns a list of datasets, each one a country/year pair
+    summaries = extract_summary.getSummaryData()
+
+    # Check which countries to update
+    countries_to_update = set([hoist_country(s) for s in summaries if checkForUpdates(s)])
+
+    print "Most recent upstream change: %s" % time.strftime('%Y-%m-%d', MOST_RECENT_CHANGE)
+
+    if len(countries_to_update):
+        print "There are %d countries that need updating" % len(countries_to_update)
+        print "\n".join(countries_to_update)
+    else:
+        print "There are no changes to report"
+        return
+
+    # Grab all the data for each country that needs updated.
+    filtered_summaries = [s for s in summaries if hoist_country(s) in countries_to_update]
+
+
+    unchanged_countries = set([hoist_country(s) for s in summaries
+                               if hoist_country(s) not in countries_to_update])
+
+    extract_summary.setup_directories()
+
+    for country in unchanged_countries:
+        gather_csvs(country)
+
+    for summary in filtered_summaries:
+        extract_summary.gatherCountry(summary)
+
+    #combine the files, pop in the eiti combined dataset table
+    datasets = extract_summary.combine_files()
+    datasets['eiti-complete-summary-table'] = update_complete_dataset(filtered_summaries)
+
+    with open('./datasets.json', 'w') as f:
+        json.dump(datasets.values(), f)
+
+    # delegate to the old import script for those items we want to update
+    eiti_import.main()
+
+if __name__=='__main__':
+    main()

--- a/harvesters/eiti/scripts/eiti_import.py
+++ b/harvesters/eiti/scripts/eiti_import.py
@@ -6,6 +6,8 @@ import urllib
 import filecmp
 import datetime
 
+session = requests.Session()
+
 failed_states = []
 
 API_HOST = os.environ['API_HOST']
@@ -28,8 +30,8 @@ def mapcountry(countryname):
         return countryname
 
 def api_get(action, data={}):
-    print API_HOST + "/api/action/"+action
-    return requests.get(
+    #print API_HOST + "/api/action/"+action
+    return session.get(
         API_HOST+"/api/action/"+action,
         params=data,
         verify=True,
@@ -37,7 +39,7 @@ def api_get(action, data={}):
 
 
 def api_post(action, data={}):
-    return requests.post(
+    return session.post(
         API_HOST+"/api/action/"+action,
         verify=True,
         json=data,

--- a/harvesters/eiti/scripts/eiti_import.py
+++ b/harvesters/eiti/scripts/eiti_import.py
@@ -249,24 +249,30 @@ def import_dataset(d):
         create_resource(d['name'], d['filename_company'], d["resource_title_company"])
         create_resource(d['name'], d['filename_government'], d["resource_title_government"])
 
-upsert_org({u'image_display_url': u'https://eiti.org/sites/all/themes/eiti/logo.svg', u'name': u'eiti', u'title': u'EITI'})
 
-datasets = {}
+def main():
+    upsert_org({u'image_display_url': u'https://eiti.org/sites/all/themes/eiti/logo.svg', u'name': u'eiti', u'title': u'EITI'})
 
-with open('./datasets.json', 'r') as f:
-    datasets = json.load(f)
+    datasets = {}
 
-holdover = None
+    with open('./datasets.json', 'r') as f:
+        datasets = json.load(f)
 
-for d in datasets:
-    if d['name'] == "eiti-complete-summary-table":
-        holdover = d
-    else:
-        import_dataset(d)
+    holdover = None
 
-if holdover is not None:
-    import_dataset(holdover) #Do last to encourage appearing at top
-    
-if failed_states:
-    print "The following or some of the following countries caused the dataset creation to fail:"
-    print failed_states
+    for d in datasets:
+        if d['name'] == "eiti-complete-summary-table":
+            holdover = d
+        else:
+            import_dataset(d)
+
+    if holdover is not None:
+        import_dataset(holdover) #Do last to encourage appearing at top
+
+    if failed_states:
+        print "The following or some of the following countries caused the dataset creation to fail:"
+        print failed_states
+
+
+if __name__== '__main__':
+    main()

--- a/harvesters/eiti/scripts/eiti_import.py
+++ b/harvesters/eiti/scripts/eiti_import.py
@@ -103,6 +103,7 @@ def update_dataset(data, existing):
 
         if key not in existing or data[key] != existing[key]:
             need_to_update = True
+            print "Dataset %s key: %s is different" % (data['name'],key)
             break
 
     if need_to_update:

--- a/harvesters/eiti/scripts/eiti_import.py
+++ b/harvesters/eiti/scripts/eiti_import.py
@@ -119,16 +119,29 @@ def update_dataset(data, existing):
         print "DATASET " + data['name'] + " UNCHANGED"
         return False, existing
 
+#Cache the datasets
+DATASET_CACHE = {}
+
+def get_dataset(name):
+    if name in DATASET_CACHE:
+        return DATASET_CACHE[name]
+
+    r = api_get("package_show", data={'id': name})
+    jsondata = r.json()
+    if jsondata.get("success"):
+        DATASET_CACHE[name] = jsondata['result']
+        return DATASET_CACHE[name]
+    # don't cache failures?
+    return {}
+
 
 def upsert_dataset(data):
     print "UPSERTING DATASET " + data['name']
-    r = api_get("package_show", data={'id': data['name']})
-    jsondata = r.json()
-    already_exists = jsondata.get("success")
-    if already_exists:
+    existing = get_dataset(data['name'])
+    if existing:
         print "DATA FROM CKAN (EXISTING):"
-        print jsondata['result']
-        return update_dataset(data, jsondata['result'])
+        print existing
+        return update_dataset(data, existing)
     else:
         return create_dataset(data)
 

--- a/harvesters/eiti/scripts/extract_summary.py
+++ b/harvesters/eiti/scripts/extract_summary.py
@@ -259,13 +259,28 @@ def gatherCountry(d):
     else:
         print "%s %s - No revenue_company or revenue_government" % (country, year)
 
-def main():
+def setup_directories():
     # Ensure output folders exist
     os.system("mkdir -p ./out/company")
     os.system("mkdir -p ./out/government")
     os.system("mkdir -p ./out/datasets")
 
+def combine_files():
+    combine.combine_csv('./out/company')
+    combine.combine_csv('./out/government')
+    datasets = combine.combine_datasets('./out/datasets')
+
+    # now that that's all done, we'll aggregate them all into a 'total' dataset
+    os.system("cat ./out/company/*company.csv | awk '!seen[$0]++' > ./out/all_unique_company.csv")
+    os.system("cat ./out/government/*government.csv | awk '!seen[$0]++' > ./out/all_unique_government.csv")
+
+    return datasets
+
+def main():
+    setup_directories()
+
     sum_data = [d for d in getSummaryData() if d.get('country', None)]
+
     total_len = len(sum_data)
     i = 0
 
@@ -287,13 +302,7 @@ def main():
         for d in sorted(sum_data, key=lambda d: d['label']):
             gatherCountry(d)
 
-    combine.combine_csv('./out/company')
-    combine.combine_csv('./out/government')
-    datasets = combine.combine_datasets('./out/datasets')
-
-    # now that that's all done, we'll aggregate them all into a 'total' dataset
-    os.system("cat ./out/company/*company.csv | awk '!seen[$0]++' > ./out/all_unique_company.csv")
-    os.system("cat ./out/government/*government.csv | awk '!seen[$0]++' > ./out/all_unique_government.csv")
+    datasets = combine_files()
 
     year_set = set()
     for d in datasets.values():

--- a/harvesters/eiti/scripts/extract_summary.py
+++ b/harvesters/eiti/scripts/extract_summary.py
@@ -96,16 +96,16 @@ def sanitizeCountryName(countryName):
 
 def getSummaryData():
     page = 1
-    done = False
     data = []
 
-    while (done is False):
+    while True:
         print("Getting summary page %s"% page)
         d = session.get(API_ENDPOINT + 'summary_data?page=%s' % page).json()['data']
         if len(d) == 0:
-            done = True
+            break
         data.extend(d)
         page += 1
+
     return data
 
 

--- a/harvesters/eiti/scripts/extract_summary.py
+++ b/harvesters/eiti/scripts/extract_summary.py
@@ -50,7 +50,10 @@ def writeCsv(name, company_or_govt, year, data):
         for l in data:
             f.write(l.encode('utf-8') + '\n')
 
+def dataset_name_fromCountry(countryName):
+    return "eiti-summary-data-table-for-%s" % sanitizeCountryName(countryName)
 
+            
 def write(meta, data, company_or_govt):
     countryName = meta['country']['label']
     year = meta['label'][-4:]
@@ -59,7 +62,7 @@ def write(meta, data, company_or_govt):
     writeCsv(sanitizedCountryName, company_or_govt, year, data)
 
     dataset_title = "EITI Summary data table for %s" % countryName
-    dataset_name = "eiti-summary-data-table-for-%s" % sanitizedCountryName
+    dataset_name = dataset_name_fromCountry(countryName)
 
     resource_title_company = "Company payments - %s" % countryName
     resource_title_government = "Revenues received by government agencies - %s" % countryName

--- a/harvesters/eiti/scripts/run_harvester.sh
+++ b/harvesters/eiti/scripts/run_harvester.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 
 mkdir ./out
-python ./extract_summary.py
-python ./eiti_import.py
+# incremental
+python ./eiti.py
+
+#full
+#python ./extract_summary.py
+#python ./eiti_import.py


### PR DESCRIPTION
This is a set of changes to let the EITI harvester only download those datasets that have had a change reported in the summary metadata.

There are also some  refactoring changes to pull out individual operations so that they can be used elsewhere. 