### PR TITLE
Commodities and Company IDS

### DIFF
--- a/harvesters/eiti/scripts/commodities.py
+++ b/harvesters/eiti/scripts/commodities.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+commodities = [
+    u'Coal, volume',
+    u'Condensate, volume',
+    u'Copper, volume',
+    u'Crude oil production revenues in kind',
+    u'Gas production revenues in kind',
+    u'Gas, volume',
+    u'Gold, volume',
+    u'NGL, volume',
+    u'Oil, volume',
+    u'Total revenue received?',
+    u'Exports - all sectors',
+    u'Exports - extractive industries',
+    u'Government revenue - all sectors',
+    u'Government revenue - extractive industries',
+    u'Gross Domestic Product - all sectors',
+    u'Gross Domestic Product - extractive industries (Gross Value Added)',
+]
+
+
+c_map = dict([(v, "commodity_%d" % ix) for ix,v in enumerate(commodities)])
+
+def truncate_date(s):
+    return  "%sT00:00:00+0000" % s.split('T')[0]
+
+c_header1 = []
+c_header2 = []
+
+for ix, v in enumerate(commodities):
+    c_header1.append('commodity_%d_value'% ix)
+    c_header1.append('commodity_%d_units'% ix)
+    c_header2.append('"%s"' % v)
+    c_header2.append("unit")
+
+header_1 = (
+    'created',
+    'changed',
+    'country',
+    'iso3',
+    'year',) + tuple(c_header1) + ('source', )
+
+header_2 = ("","", "","","") + tuple(c_header2) + ('',)
+
+
+def filter_commodity(data):
+    reports =  [d for d in data if 'country' in d and d['country'].get('reports', None)]
+
+    seen = set()
+    lines = [header_1, header_2]
+    for d in reports:
+        reports = d['country'].get('reports', None)
+        source = d.get('report_file', '')
+        if reports:
+            for label, values in reports.items():
+                country_year = (d['country']['label'], label)
+                if country_year in seen:
+                    continue
+                seen.add(country_year)
+                items = {}
+                for rpt in values:
+                    c = rpt.get('commodity', None)
+                    if c_map.get(c, None):
+                        items[c_map[c]] = {
+                            'value': rpt.get('value', ''),
+                            'unit': rpt.get('unit', '')
+                            }
+                c_line = []
+                for ix, v in enumerate(commodities):
+                    elt = "commodity_%d" % ix
+                    c_line.append(items.get(elt, {}).get('value',''))
+                    c_line.append(items.get(elt, {}).get('unit',''))
+
+                line = (truncate_date(d['created']),
+                        truncate_date(d['changed']),
+                        d['country']['label'],
+                        d['country']['iso3'],
+                        label) + tuple(c_line) + \
+                        (source,)
+
+
+                lines.append(line)
+
+    return lines

--- a/harvesters/eiti/scripts/eiti.py
+++ b/harvesters/eiti/scripts/eiti.py
@@ -128,6 +128,7 @@ def main():
     # SummaryData returns a list of datasets, each one a country/year pair
     summaries = extract_summary.getSummaryData()
 
+    extract_summary.setup_directories()
     if update_all:
         for summary in summaries:
             extract_summary.gatherCountry(summary)
@@ -151,8 +152,6 @@ def main():
 
         unchanged_countries = set([hoist_country(s) for s in summaries
                                    if hoist_country(s) not in countries_to_update])
-
-        extract_summary.setup_directories()
 
         for country in unchanged_countries:
             gather_csvs(country)

--- a/harvesters/eiti/scripts/extract_summary.py
+++ b/harvesters/eiti/scripts/extract_summary.py
@@ -177,7 +177,7 @@ def getLineForRevenue(d, company, company_or_govt):
     if company_or_govt == 'company':
         entity_name = orglabel.replace('"', '').replace("\n", "; ").strip()
         company_extras = (",".join(organisations[cid].get('commodities',None) or []).encode('utf-8'),
-                          (organisations[cid].get('identification', '') or '').encode('utf-8'))
+                          (organisations[cid].get('identification', '') or '').replace("\n", ",").encode('utf-8'))
     else:
         entity_name = rec_agency_name.replace('"', '').replace("\n", "; ").strip()
         company_extras = tuple()

--- a/harvesters/eiti/scripts/extract_summary.py
+++ b/harvesters/eiti/scripts/extract_summary.py
@@ -68,9 +68,6 @@ def write(meta, data, company_or_govt):
     year = meta['label'][-4:]
     sanitizedCountryName = sanitizeCountryName(countryName)
 
-    if not len(data):
-        print "empty data for %s %s, %s" % (sanitizedCountryName, year, company_or_govt)
-        return
     writeCsv(sanitizedCountryName, company_or_govt, year, data)
 
     dataset_title = "EITI Summary data table for %s" % countryName

--- a/harvesters/eiti/scripts/extract_summary.py
+++ b/harvesters/eiti/scripts/extract_summary.py
@@ -44,7 +44,7 @@ def writeCsv(name, company_or_govt, year, data):
 
     #Split files https://github.com/NRGI/resourcedata.org/issues/13
     if company_or_govt == 'company':
-        data.insert(0, 'created,changed,country,iso3,year,start_date,end_date,company_name,gfs_code,gfs_description,name_of_revenue_stream,currency_code,currency_rate,value_reported,value_reported_as_USD,reporting_url,commodities'.split(','))
+        data.insert(0, 'created,changed,country,iso3,year,start_date,end_date,company_name,gfs_code,gfs_description,name_of_revenue_stream,currency_code,currency_rate,value_reported,value_reported_as_USD,reporting_url,commodities,company_identification'.split(','))
     else:
         data.insert(0, 'created,changed,country,iso3,year,start_date,end_date,government_agency_name,gfs_code,gfs_description,name_of_revenue_stream,currency_code,currency_rate,value_reported,value_reported_as_USD,reporting_url'.split(','))
 
@@ -179,10 +179,11 @@ def getLineForRevenue(d, company, company_or_govt):
     entity_name = ''
     if company_or_govt == 'company':
         entity_name = orglabel.replace('"', '').replace("\n", "; ").strip()
-        commodities = (",".join(organisations[cid].get('commodities',None) or []),)
+        company_extras = (",".join(organisations[cid].get('commodities',None) or []).encode('utf-8'),
+                          (organisations[cid].get('identification', '') or '').encode('utf-8'))
     else:
         entity_name = rec_agency_name.replace('"', '').replace("\n", "; ").strip()
-        commodities = tuple()
+        company_extras = tuple()
 
 
     #Split files https://github.com/NRGI/resourcedata.org/issues/13
@@ -203,7 +204,7 @@ def getLineForRevenue(d, company, company_or_govt):
         valreported,
         valreportedusd,
         companyurl,
-        ) + commodities
+        ) + company_extras
 
 
 def gatherCountry(d):


### PR DESCRIPTION
This PR adds two columns to the company summary CSV files:
* Commodities
* Company id

In each case, the field can be a multi-valued field, comma separated, enclosed by quotes. 

Additionally, since we are essentially rewriting all of the CSV files, there is a new environment flag:
`UPDATE_ALL=1` ignores the modification date on the summary data and re-imports the summary data. 

`docker run --rm -e "UPDATE_ALL=1" -e "API_KEY=[api key]" -e "API_HOST=https://staging.resourcedata.org" eiti_harvester`